### PR TITLE
Fixes to Render Pass Cache

### DIFF
--- a/PrivateInclude/RenderPassCache.hpp
+++ b/PrivateInclude/RenderPassCache.hpp
@@ -13,13 +13,15 @@ namespace R2::VK
         VkFormat format;
         VkAttachmentLoadOp loadOp;
         VkAttachmentStoreOp storeOp;
+        VkSampleCountFlagBits samples;
 
         bool operator==(const RenderPassAttachment& other) const
         {
             return
                 format == other.format &&
                 loadOp == other.loadOp &&
-                storeOp == other.storeOp;
+                storeOp == other.storeOp &&
+                samples == other.samples;
         }
     };
     
@@ -92,6 +94,7 @@ namespace std
             hash_combine(result, c.format);
             hash_combine(result, c.loadOp);
             hash_combine(result, c.storeOp);
+            hash_combine(result, c.samples);
             return result;
         }
     };

--- a/PrivateInclude/RenderPassCache.hpp
+++ b/PrivateInclude/RenderPassCache.hpp
@@ -1,10 +1,7 @@
 #pragma once
 #include <stdint.h>
 #include <unordered_map>
-
-#ifdef __ANDROID__
-#define R2_USE_RENDERPASS_FALLBACK
-#endif
+#include <volk.h>
 
 namespace R2::VK
 {

--- a/PrivateInclude/VKSyncLegacyHelpers.hpp
+++ b/PrivateInclude/VKSyncLegacyHelpers.hpp
@@ -1,0 +1,57 @@
+#pragma once
+#include <R2/VKEnums.hpp>
+#include <volk.h>
+
+namespace R2::VK
+{
+    inline bool hasAccessBit(AccessFlags flags, AccessFlags test)
+    {
+        return ((uint64_t)flags & (uint64_t)test) == (uint64_t)test;
+    }
+
+    inline bool hasStageBit(PipelineStageFlags flags, PipelineStageFlags test)
+    {
+        return ((uint64_t)flags & (uint64_t)test) == (uint64_t)test;
+    }
+
+    inline VkAccessFlags getOldAccessFlags(AccessFlags access)
+    {
+        VkAccessFlags flagBits = 0;
+        flagBits = (VkAccessFlagBits)((uint64_t)(access) & 0xFFFFFFFF);
+
+        if (hasAccessBit(access, AccessFlags::ShaderSampledRead)  ||
+            hasAccessBit(access, AccessFlags::ShaderStorageRead))
+        {
+            flagBits |= VK_ACCESS_SHADER_READ_BIT;
+        }
+
+        if (hasAccessBit(access, AccessFlags::ShaderStorageWrite))
+        {
+            flagBits |= VK_ACCESS_SHADER_WRITE_BIT;
+        }
+
+        return flagBits;
+    }
+
+    inline VkPipelineStageFlags getOldPipelineStageFlags(PipelineStageFlags flags)
+    {
+        VkPipelineStageFlags oldFlags = 0;
+        oldFlags = (VkPipelineStageFlags)((uint64_t)(flags) & 0xFFFFFFFF);
+
+        if (hasStageBit(flags, PipelineStageFlags::Copy) ||
+            hasStageBit(flags, PipelineStageFlags::Resolve) ||
+            hasStageBit(flags, PipelineStageFlags::Blit) ||
+            hasStageBit(flags, PipelineStageFlags::Clear))
+        {
+            oldFlags |= VK_PIPELINE_STAGE_TRANSFER_BIT;
+        }
+
+        if (hasStageBit(flags, PipelineStageFlags::IndexInput) ||
+            hasStageBit(flags, PipelineStageFlags::VertexAttributeInput))
+        {
+            oldFlags |= VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
+        }
+
+        return oldFlags;
+    }
+}

--- a/PublicInclude/R2/VKCore.hpp
+++ b/PublicInclude/R2/VKCore.hpp
@@ -82,6 +82,7 @@ namespace R2::VK
 	{
 		bool RayTracing;
 		bool VariableRateShading;
+		bool DynamicRendering;
 	};
 
 	void onFailedVkCheck(int res, const char* file, int line);

--- a/Source/VK/RenderPassCache.cpp
+++ b/Source/VK/RenderPassCache.cpp
@@ -19,7 +19,7 @@ namespace R2::VK
         return VkAttachmentDescription {
             .flags = 0,
             .format = attachment.format,
-            .samples = VK_SAMPLE_COUNT_1_BIT,
+            .samples = attachment.samples,
             .loadOp = attachment.loadOp,
             .storeOp = attachment.storeOp,
             .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,

--- a/Source/VK/VKCommandBuffer.cpp
+++ b/Source/VK/VKCommandBuffer.cpp
@@ -329,10 +329,13 @@ namespace R2::VK
 
     void CommandBuffer::EndRendering()
     {
-#ifndef R2_USE_RENDERPASS_FALLBACK
-        vkCmdEndRendering(cb);
-#else
-        vkCmdEndRenderPass(cb);
-#endif
+        if (g_renderPassCache == nullptr)
+        {
+            vkCmdEndRendering(cb);
+        }
+        else
+        {
+            vkCmdEndRenderPass(cb);
+        }
     }
 }

--- a/Source/VK/VKCommandBuffer.cpp
+++ b/Source/VK/VKCommandBuffer.cpp
@@ -131,35 +131,38 @@ namespace R2::VK
 
     void CommandBuffer::TextureBarrier(Texture* tex, PipelineStageFlags srcStage, PipelineStageFlags dstStage, AccessFlags srcAccess, AccessFlags dstAccess)
     {
-        #ifdef USE_SYNC_2
-        VkImageMemoryBarrier2 imageBarrier { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2 };
-        imageBarrier.image = tex->GetNativeHandle();
-        imageBarrier.oldLayout = imageBarrier.newLayout = (VkImageLayout)tex->lastLayout;
-        tex->lastAccess = dstAccess;
-        imageBarrier.srcStageMask = (VkPipelineStageFlags2)srcStage;
-        imageBarrier.dstStageMask = (VkPipelineStageFlags2)dstStage;
-        imageBarrier.srcAccessMask = (VkAccessFlags2)srcAccess;
-        imageBarrier.dstAccessMask = (VkAccessFlags2)dstAccess;
-        imageBarrier.subresourceRange = VkImageSubresourceRange { tex->getAspectFlags(), 0, (uint32_t)tex->GetNumMips(), 0, (uint32_t)tex->GetLayerCount() };
+        if (vkCmdPipelineBarrier2 != NULL)
+        {
+            VkImageMemoryBarrier2 imageBarrier { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2 };
+            imageBarrier.image = tex->GetNativeHandle();
+            imageBarrier.oldLayout = imageBarrier.newLayout = (VkImageLayout)tex->lastLayout;
+            tex->lastAccess = dstAccess;
+            imageBarrier.srcStageMask = (VkPipelineStageFlags2)srcStage;
+            imageBarrier.dstStageMask = (VkPipelineStageFlags2)dstStage;
+            imageBarrier.srcAccessMask = (VkAccessFlags2)srcAccess;
+            imageBarrier.dstAccessMask = (VkAccessFlags2)dstAccess;
+            imageBarrier.subresourceRange = VkImageSubresourceRange { tex->getAspectFlags(), 0, (uint32_t)tex->GetNumMips(), 0, (uint32_t)tex->GetLayerCount() };
 
-        VkDependencyInfo di { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
-        di.imageMemoryBarrierCount = 1;
-        di.pImageMemoryBarriers = &imageBarrier;
-        di.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
-        vkCmdPipelineBarrier2(cb, &di);
-        #else
-        VkImageMemoryBarrier imageBarrier = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
-        imageBarrier.image = tex->GetNativeHandle();
-        imageBarrier.oldLayout = imageBarrier.newLayout = (VkImageLayout)tex->lastLayout;
-        tex->lastAccess = dstAccess;
-        imageBarrier.srcAccessMask = getOldAccessFlags(srcAccess);
-        imageBarrier.dstAccessMask = getOldAccessFlags(dstAccess);
-        imageBarrier.subresourceRange = VkImageSubresourceRange { tex->getAspectFlags(), 0, (uint32_t)tex->GetNumMips(), 0, (uint32_t)tex->GetLayerCount() };
-        imageBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        imageBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            VkDependencyInfo di { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
+            di.imageMemoryBarrierCount = 1;
+            di.pImageMemoryBarriers = &imageBarrier;
+            di.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+            vkCmdPipelineBarrier2(cb, &di);
+        }
+        else
+        {
+            VkImageMemoryBarrier imageBarrier = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
+            imageBarrier.image = tex->GetNativeHandle();
+            imageBarrier.oldLayout = imageBarrier.newLayout = (VkImageLayout)tex->lastLayout;
+            tex->lastAccess = dstAccess;
+            imageBarrier.srcAccessMask = getOldAccessFlags(srcAccess);
+            imageBarrier.dstAccessMask = getOldAccessFlags(dstAccess);
+            imageBarrier.subresourceRange = VkImageSubresourceRange { tex->getAspectFlags(), 0, (uint32_t)tex->GetNumMips(), 0, (uint32_t)tex->GetLayerCount() };
+            imageBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            imageBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 
-        vkCmdPipelineBarrier(cb, getOldPipelineStageFlags(srcStage), getOldPipelineStageFlags(dstStage), 0, 0, nullptr, 0, nullptr, 1, &imageBarrier);
-        #endif
+            vkCmdPipelineBarrier(cb, getOldPipelineStageFlags(srcStage), getOldPipelineStageFlags(dstStage), 0, 0, nullptr, 0, nullptr, 1, &imageBarrier);
+        }
     }
 
     VkOffset3D convertOffset(Offset3D offset)

--- a/Source/VK/VKCore.cpp
+++ b/Source/VK/VKCore.cpp
@@ -28,9 +28,7 @@ namespace R2::VK
     const uint32_t NUM_FRAMES_IN_FLIGHT = 2;
     const size_t STAGING_BUFFER_SIZE = 64_MB;
     IDebugOutputReceiver* g_dbgOutRecv;
-#ifdef R2_USE_RENDERPASS_FALLBACK
     RenderPassCache* g_renderPassCache;
-#endif
     
     void onFailedVkCheck(int res, const char* file, int line)
     {
@@ -63,10 +61,6 @@ namespace R2::VK
         createCommandPool();
         createAllocator();
         createDescriptorPool();
-
-#ifdef R2_USE_RENDERPASS_FALLBACK
-        g_renderPassCache = new RenderPassCache(this);
-#endif
 
         VkPhysicalDeviceProperties deviceProps{};
         vkGetPhysicalDeviceProperties(handles.PhysicalDevice, &deviceProps);

--- a/Source/VK/VKCoreInitialization.cpp
+++ b/Source/VK/VKCoreInitialization.cpp
@@ -225,6 +225,7 @@ namespace R2::VK
         VkDeviceCreateInfo dci{VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
         supportedFeatures.RayTracing = checkRaytracingSupport(handles.PhysicalDevice);
         supportedFeatures.VariableRateShading = checkExtensionSupport(handles.PhysicalDevice, VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
+        supportedFeatures.DynamicRendering = checkExtensionSupport(handles.PhysicalDevice, VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
 
         // Features
         // ========

--- a/Source/VK/VKCoreInitialization.cpp
+++ b/Source/VK/VKCoreInitialization.cpp
@@ -1,5 +1,6 @@
 #include <R2/VKCore.hpp>
 #include <R2/R2.hpp>
+#include <RenderPassCache.hpp>
 #include <volk.h>
 #ifdef __ANDROID__
 #include <vulkan/vulkan_android.h>
@@ -226,6 +227,15 @@ namespace R2::VK
         supportedFeatures.RayTracing = checkRaytracingSupport(handles.PhysicalDevice);
         supportedFeatures.VariableRateShading = checkExtensionSupport(handles.PhysicalDevice, VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
         supportedFeatures.DynamicRendering = checkExtensionSupport(handles.PhysicalDevice, VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+
+        if (!supportedFeatures.DynamicRendering)
+        {
+            g_renderPassCache = new RenderPassCache(this);
+        }
+        else
+        {
+            g_renderPassCache = nullptr;
+        }
 
         // Features
         // ========

--- a/Source/VK/VKPipeline.cpp
+++ b/Source/VK/VKPipeline.cpp
@@ -390,7 +390,8 @@ namespace R2::VK
             {
                 .format = (VkFormat)depthFormat,
                 .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
-                .storeOp = VK_ATTACHMENT_STORE_OP_STORE
+                .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+                .samples = (VkSampleCountFlagBits)numSamples
             };
             rpKey.useDepth = true;
         }
@@ -401,7 +402,8 @@ namespace R2::VK
             {
                 .format = (VkFormat)attachmentFormats[0],
                 .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
-                .storeOp = VK_ATTACHMENT_STORE_OP_STORE
+                .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+                .samples = (VkSampleCountFlagBits)numSamples
             };
             rpKey.useColor = true;
         }

--- a/Source/VK/VKRenderPass.cpp
+++ b/Source/VK/VKRenderPass.cpp
@@ -164,7 +164,8 @@ namespace R2::VK
             {
                 .format = (VkFormat)depthAttachment.Texture->GetFormat(),
                 .loadOp = convertLoadOp(depthAttachment.LoadOp),
-                .storeOp = convertStoreOp(depthAttachment.StoreOp)
+                .storeOp = convertStoreOp(depthAttachment.StoreOp),
+                .samples = (VkSampleCountFlagBits)depthAttachment.Texture->GetSamples()
             };
             key.useDepth = true;
         }
@@ -175,7 +176,8 @@ namespace R2::VK
             {
                 .format = (VkFormat)colorAttachment.Texture->GetFormat(),
                 .loadOp = convertLoadOp(colorAttachment.LoadOp),
-                .storeOp = convertStoreOp(colorAttachment.StoreOp)
+                .storeOp = convertStoreOp(colorAttachment.StoreOp),
+                .samples = (VkSampleCountFlagBits)colorAttachment.Texture->GetSamples()
             };
             key.useColor = true;
         }

--- a/Source/VK/VKRenderPass.cpp
+++ b/Source/VK/VKRenderPass.cpp
@@ -120,173 +120,179 @@ namespace R2::VK
         if (depthAttachment.Texture)
             depthAttachment.Texture->Acquire(cb, ImageLayout::AttachmentOptimal, AccessFlags::DepthStencilAttachmentReadWrite, PipelineStageFlags::LateFragmentTests);
 
-#ifndef R2_USE_RENDERPASS_FALLBACK
-        VkRenderingInfo renderInfo{ VK_STRUCTURE_TYPE_RENDERING_INFO };
-        renderInfo.renderArea = VkRect2D{ { 0, 0 }, { width, height }, };
-        renderInfo.layerCount = 1;
-        renderInfo.colorAttachmentCount = numColorAttachments;
-        renderInfo.viewMask = viewMask;
-
-        VkRenderingAttachmentInfo depthAttachmentInfo{ VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-        if (depthAttachment.Texture)
+        if (g_renderPassCache == nullptr)
         {
-            depthAttachmentInfo.clearValue.depthStencil.depth = depthAttachment.ClearValue.DepthStencil.Depth;
-            depthAttachmentInfo.imageView = depthAttachment.Texture->GetView();
-            depthAttachmentInfo.storeOp = convertStoreOp(depthAttachment.StoreOp);
-            depthAttachmentInfo.loadOp = convertLoadOp(depthAttachment.LoadOp);
-            depthAttachmentInfo.imageLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-            renderInfo.pDepthAttachment = &depthAttachmentInfo;
-        }
+            VkRenderingInfo renderInfo{ VK_STRUCTURE_TYPE_RENDERING_INFO };
+            renderInfo.renderArea = VkRect2D{ { 0, 0 }, { width, height }, };
+            renderInfo.layerCount = 1;
+            renderInfo.colorAttachmentCount = numColorAttachments;
+            renderInfo.viewMask = viewMask;
 
-        // Is alloca the right choice here? We certainly don't want to heap allocate.
-        VkRenderingAttachmentInfo* colorAttachmentInfos = 
-            static_cast<VkRenderingAttachmentInfo*>(alloca(sizeof(VkRenderingAttachmentInfo) * numColorAttachments));
-
-        for (int i = 0; i < numColorAttachments; i++)
-        {
-            const AttachmentInfo& colorAttachment = colorAttachments[i];
-            VkRenderingAttachmentInfo& colorAttachmentInfo = colorAttachmentInfos[i];
-            colorAttachmentInfo = VkRenderingAttachmentInfo{ VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-
-            for (int j = 0; j < 4; j++)
-                colorAttachmentInfo.clearValue.color.uint32[j] = colorAttachment.ClearValue.Color.Uint32[j];
-
-            colorAttachmentInfo.imageView = colorAttachment.Texture->GetView();
-            colorAttachmentInfo.storeOp = convertStoreOp(colorAttachment.StoreOp);
-            colorAttachmentInfo.loadOp = convertLoadOp(colorAttachment.LoadOp);
-            colorAttachmentInfo.imageLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-        }
-
-        renderInfo.pColorAttachments = colorAttachmentInfos;
-
-        VkRenderingFragmentShadingRateAttachmentInfoKHR fsrAttachmentInfo{ VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR };
-        if (useFragmentShadingRateAttachment)
-        {
-            fragmentShadingRateAttachment.tex->Acquire(cb, VK::ImageLayout::FragmentShadingRateOptimal,
-                VK::AccessFlags::FragmentShadingRateAttachmentRead, VK::PipelineStageFlags::FragmentShadingRateAttachment);
-
-            fsrAttachmentInfo.imageView = fragmentShadingRateAttachment.tex->GetView();
-            fsrAttachmentInfo.imageLayout = VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR;
-            fsrAttachmentInfo.shadingRateAttachmentTexelSize.width = fragmentShadingRateAttachment.texelWidth;
-            fsrAttachmentInfo.shadingRateAttachmentTexelSize.height = fragmentShadingRateAttachment.texelHeight;
-
-            renderInfo.pNext = &fsrAttachmentInfo;
-        }
-
-        vkCmdBeginRendering(cb.GetNativeHandle(), &renderInfo);
-#else
-        // For now we only support a max of 1 color attachment
-        assert(numColorAttachments <= 1);
-        
-        const AttachmentInfo& colorAttachment = colorAttachments[0];
-        
-        RenderPassKey key
-        {
-            .viewMask = viewMask
-        };
-
-        if (depthAttachment.Texture)
-        {
-            key.depthAttachment = RenderPassAttachment
+            VkRenderingAttachmentInfo depthAttachmentInfo{ VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
+            if (depthAttachment.Texture)
             {
-                .format = (VkFormat)depthAttachment.Texture->GetFormat(),
-                .loadOp = convertLoadOp(depthAttachment.LoadOp),
-                .storeOp = convertStoreOp(depthAttachment.StoreOp),
-                .samples = (VkSampleCountFlagBits)depthAttachment.Texture->GetSamples()
-            };
-            key.useDepth = true;
-        }
+                depthAttachmentInfo.clearValue.depthStencil.depth = depthAttachment.ClearValue.DepthStencil.Depth;
+                depthAttachmentInfo.imageView = depthAttachment.Texture->GetView();
+                depthAttachmentInfo.storeOp = convertStoreOp(depthAttachment.StoreOp);
+                depthAttachmentInfo.loadOp = convertLoadOp(depthAttachment.LoadOp);
+                depthAttachmentInfo.imageLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
+                renderInfo.pDepthAttachment = &depthAttachmentInfo;
+            }
 
-        if (numColorAttachments > 0)
-        {
-            key.colorAttachment = RenderPassAttachment
+            // Is alloca the right choice here? We certainly don't want to heap allocate.
+            VkRenderingAttachmentInfo* colorAttachmentInfos =
+                static_cast<VkRenderingAttachmentInfo*>(alloca(sizeof(VkRenderingAttachmentInfo) * numColorAttachments));
+
+            for (int i = 0; i < numColorAttachments; i++)
             {
-                .format = (VkFormat)colorAttachment.Texture->GetFormat(),
-                .loadOp = convertLoadOp(colorAttachment.LoadOp),
-                .storeOp = convertStoreOp(colorAttachment.StoreOp),
-                .samples = (VkSampleCountFlagBits)colorAttachment.Texture->GetSamples()
-            };
-            key.useColor = true;
+                const AttachmentInfo& colorAttachment = colorAttachments[i];
+                VkRenderingAttachmentInfo& colorAttachmentInfo = colorAttachmentInfos[i];
+                colorAttachmentInfo = VkRenderingAttachmentInfo{ VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
+
+                for (int j = 0; j < 4; j++)
+                    colorAttachmentInfo.clearValue.color.uint32[j] = colorAttachment.ClearValue.Color.Uint32[j];
+
+                colorAttachmentInfo.imageView = colorAttachment.Texture->GetView();
+                colorAttachmentInfo.storeOp = convertStoreOp(colorAttachment.StoreOp);
+                colorAttachmentInfo.loadOp = convertLoadOp(colorAttachment.LoadOp);
+                colorAttachmentInfo.imageLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
+            }
+
+            renderInfo.pColorAttachments = colorAttachmentInfos;
+
+            VkRenderingFragmentShadingRateAttachmentInfoKHR fsrAttachmentInfo{ VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR };
+            if (useFragmentShadingRateAttachment)
+            {
+                fragmentShadingRateAttachment.tex->Acquire(cb, VK::ImageLayout::FragmentShadingRateOptimal,
+                    VK::AccessFlags::FragmentShadingRateAttachmentRead, VK::PipelineStageFlags::FragmentShadingRateAttachment);
+
+                fsrAttachmentInfo.imageView = fragmentShadingRateAttachment.tex->GetView();
+                fsrAttachmentInfo.imageLayout = VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR;
+                fsrAttachmentInfo.shadingRateAttachmentTexelSize.width = fragmentShadingRateAttachment.texelWidth;
+                fsrAttachmentInfo.shadingRateAttachmentTexelSize.height = fragmentShadingRateAttachment.texelHeight;
+
+                renderInfo.pNext = &fsrAttachmentInfo;
+            }
+
+            vkCmdBeginRendering(cb.GetNativeHandle(), &renderInfo);
         }
-        
-        VkRenderPass renderPass = g_renderPassCache->GetPass(key);
-        FramebufferKey framebufferKey
+        else
         {
-            .width = width,
-            .height = height,
-            .renderPass = renderPass,
-            .numTextures = 0,
-            .layerCount = 1
-        };
-        VkImageView attachmentViews[2];
-        VkClearValue clearVals[2];
-        
-        if (depthAttachment.Texture)
-        {
-            framebufferKey.textureFormats[framebufferKey.numTextures] =
-                (VkFormat)depthAttachment.Texture->GetFormat();
-            
-            framebufferKey.textureUsages[framebufferKey.numTextures] =
+            // For now we only support a max of 1 color attachment
+            assert(numColorAttachments <= 1);
+
+            const AttachmentInfo& colorAttachment = colorAttachments[0];
+
+            RenderPassKey key
+            {
+                .viewMask = viewMask
+            };
+
+            if (depthAttachment.Texture)
+            {
+                key.depthAttachment = RenderPassAttachment
+                {
+                    .format = (VkFormat)depthAttachment.Texture->GetFormat(),
+                    .loadOp = convertLoadOp(depthAttachment.LoadOp),
+                    .storeOp = convertStoreOp(depthAttachment.StoreOp),
+                    .samples = (VkSampleCountFlagBits)depthAttachment.Texture->GetSamples()
+                };
+                key.useDepth = true;
+            }
+
+            if (numColorAttachments > 0)
+            {
+                key.colorAttachment = RenderPassAttachment
+                {
+                    .format = (VkFormat)colorAttachment.Texture->GetFormat(),
+                    .loadOp = convertLoadOp(colorAttachment.LoadOp),
+                    .storeOp = convertStoreOp(colorAttachment.StoreOp),
+                    .samples = (VkSampleCountFlagBits)colorAttachment.Texture->GetSamples()
+                };
+                key.useColor = true;
+            }
+
+            VkRenderPass renderPass = g_renderPassCache->GetPass(key);
+            FramebufferKey framebufferKey
+            {
+                .width = width,
+                .height = height,
+                .renderPass = renderPass,
+                .numTextures = 0,
+                .layerCount = 1
+            };
+            VkImageView attachmentViews[2];
+            VkClearValue clearVals[2];
+
+            if (depthAttachment.Texture)
+            {
+                framebufferKey.textureFormats[framebufferKey.numTextures] =
+                    (VkFormat)depthAttachment.Texture->GetFormat();
+
+                framebufferKey.textureUsages[framebufferKey.numTextures] =
                     depthAttachment.Texture->GetUsageFlags();
-            
-            framebufferKey.textureFlags[framebufferKey.numTextures] =
+
+                framebufferKey.textureFlags[framebufferKey.numTextures] =
                     depthAttachment.Texture->GetImageFlags();
-            
-            attachmentViews[framebufferKey.numTextures] = depthAttachment.Texture->GetView();
-            framebufferKey.layerCount = depthAttachment.Texture->GetLayerCount();
-            clearVals[framebufferKey.numTextures].depthStencil.depth = depthAttachment.ClearValue.DepthStencil.Depth;
-            framebufferKey.numTextures++;
-        }
-        
-        if (numColorAttachments > 0)
-        {
-            framebufferKey.textureFormats[framebufferKey.numTextures] =
-                (VkFormat)colorAttachment.Texture->GetFormat();
-            
-            framebufferKey.textureUsages[framebufferKey.numTextures] =
+
+                attachmentViews[framebufferKey.numTextures] = depthAttachment.Texture->GetView();
+                framebufferKey.layerCount = depthAttachment.Texture->GetLayerCount();
+                clearVals[framebufferKey.numTextures].depthStencil.depth = depthAttachment.ClearValue.DepthStencil.Depth;
+                framebufferKey.numTextures++;
+            }
+
+            if (numColorAttachments > 0)
+            {
+                framebufferKey.textureFormats[framebufferKey.numTextures] =
+                    (VkFormat)colorAttachment.Texture->GetFormat();
+
+                framebufferKey.textureUsages[framebufferKey.numTextures] =
                     colorAttachment.Texture->GetUsageFlags();
-            
-            framebufferKey.textureFlags[framebufferKey.numTextures] =
+
+                framebufferKey.textureFlags[framebufferKey.numTextures] =
                     colorAttachment.Texture->GetImageFlags();
-            
-            attachmentViews[framebufferKey.numTextures] = colorAttachment.Texture->GetView();
-            framebufferKey.layerCount = colorAttachment.Texture->GetLayerCount();
-            for (int j = 0; j < 4; j++)
-                clearVals[framebufferKey.numTextures].color.uint32[j] = colorAttachment.ClearValue.Color.Uint32[j];
 
-            framebufferKey.numTextures++;
+                attachmentViews[framebufferKey.numTextures] = colorAttachment.Texture->GetView();
+                framebufferKey.layerCount = colorAttachment.Texture->GetLayerCount();
+                for (int j = 0; j < 4; j++)
+                    clearVals[framebufferKey.numTextures].color.uint32[j] = colorAttachment.ClearValue.Color.Uint32[j];
+
+                framebufferKey.numTextures++;
+            }
+
+            VkFramebuffer framebuffer = g_renderPassCache->GetFramebuffer(framebufferKey);
+
+            VkRenderPassAttachmentBeginInfo attachBeginInfo
+            {
+                .sType = VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO,
+                .attachmentCount = framebufferKey.numTextures,
+                .pAttachments = attachmentViews
+            };
+
+            VkRenderPassBeginInfo beginInfo
+            {
+                .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+                .pNext = &attachBeginInfo,
+                .renderPass = renderPass,
+                .framebuffer = framebuffer,
+                .renderArea = VkRect2D { 0, 0, width, height },
+                .clearValueCount = framebufferKey.numTextures,
+                .pClearValues = clearVals
+            };
+
+            vkCmdBeginRenderPass(cb.GetNativeHandle(), &beginInfo, VK_SUBPASS_CONTENTS_INLINE);
         }
-
-        VkFramebuffer framebuffer = g_renderPassCache->GetFramebuffer(framebufferKey);
-
-        VkRenderPassAttachmentBeginInfo attachBeginInfo
-        {
-            .sType = VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO,
-            .attachmentCount = framebufferKey.numTextures,
-            .pAttachments = attachmentViews
-        };
-
-        VkRenderPassBeginInfo beginInfo
-        {
-            .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-            .pNext = &attachBeginInfo,
-            .renderPass = renderPass,
-            .framebuffer = framebuffer,
-            .renderArea = VkRect2D { 0, 0, width, height },
-            .clearValueCount = framebufferKey.numTextures,
-            .pClearValues = clearVals
-        };
-
-        vkCmdBeginRenderPass(cb.GetNativeHandle(), &beginInfo, VK_SUBPASS_CONTENTS_INLINE);
-#endif
     }
 
     void RenderPass::End(CommandBuffer cb)
     {
-#ifndef R2_USE_RENDERPASS_FALLBACK
-        vkCmdEndRendering(cb.GetNativeHandle());
-#else
-        vkCmdEndRenderPass(cb.GetNativeHandle());
-#endif
+        if (g_renderPassCache == nullptr)
+        {
+            vkCmdEndRendering(cb.GetNativeHandle());
+        }
+        else
+        {
+            vkCmdEndRenderPass(cb.GetNativeHandle());
+        }
     }
 }

--- a/Source/VK/VKTexture.cpp
+++ b/Source/VK/VKTexture.cpp
@@ -4,6 +4,7 @@
 #include <R2/VKDeletionQueue.hpp>
 #include <R2/VKEnums.hpp>
 #include <R2/VKUtil.hpp>
+#include <VKSyncLegacyHelpers.hpp>
 #include <volk.h>
 #include <vk_mem_alloc.h>
 #include <assert.h>
@@ -344,57 +345,6 @@ namespace R2::VK
     TextureFormat Texture::GetFormat()
     {
         return format;
-    }
-
-    bool hasAccessBit(AccessFlags flags, AccessFlags test)
-    {
-        return ((uint64_t)flags & (uint64_t)test) == (uint64_t)test;
-    }
-
-    bool hasStageBit(PipelineStageFlags flags, PipelineStageFlags test)
-    {
-        return ((uint64_t)flags & (uint64_t)test) == (uint64_t)test;
-    }
-
-    VkAccessFlags getOldAccessFlags(AccessFlags access)
-    {
-        VkAccessFlags flagBits = 0;
-        flagBits = (VkAccessFlagBits)((uint64_t)(access) & 0xFFFFFFFF);
-
-        if (hasAccessBit(access, AccessFlags::ShaderSampledRead)  ||
-            hasAccessBit(access, AccessFlags::ShaderStorageRead))
-        {
-            flagBits |= VK_ACCESS_SHADER_READ_BIT;
-        }
-
-        if (hasAccessBit(access, AccessFlags::ShaderStorageWrite))
-        {
-            flagBits |= VK_ACCESS_SHADER_WRITE_BIT;
-        }
-
-        return flagBits;
-    }
-
-    VkPipelineStageFlags getOldPipelineStageFlags(PipelineStageFlags flags)
-    {
-        VkPipelineStageFlags oldFlags = 0;
-        oldFlags = (VkPipelineStageFlags)((uint64_t)(flags) & 0xFFFFFFFF);
-
-        if (hasStageBit(flags, PipelineStageFlags::Copy) ||
-            hasStageBit(flags, PipelineStageFlags::Resolve) ||
-            hasStageBit(flags, PipelineStageFlags::Blit) ||
-            hasStageBit(flags, PipelineStageFlags::Clear))
-        {
-            oldFlags |= VK_PIPELINE_STAGE_TRANSFER_BIT;
-        }
-
-        if (hasStageBit(flags, PipelineStageFlags::IndexInput) ||
-            hasStageBit(flags, PipelineStageFlags::VertexAttributeInput))
-        {
-            oldFlags |= VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
-        }
-
-        return oldFlags;
     }
 
     void Texture::Acquire(CommandBuffer cb, ImageLayout layout, AccessFlags access, PipelineStageFlags stage)


### PR DESCRIPTION
* Fix MSAA textures in `RenderPassCache`
* Fix `CommandBuffer::TextureBarrier` in platforms that don't support Vulkan sync 2
* Change vulkan sync 2 support to activate dynamically at runtime instead of as a compile define
* Change dynamic rendering support to activate dynamically at runtime instead of as a compile define